### PR TITLE
fix/room id

### DIFF
--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -17,7 +17,7 @@ export const GET = async (req: NextRequest) => {
     const numberOfQuestion = parseInt(numberOfQuestionQueryNotFormatted);
 
     const questions = await prisma.$queryRaw`
-      SELECT * FROM "Question"
+      SELECT * FROM "public"."Question"
       ORDER BY RANDOM()
       LIMIT ${numberOfQuestion}
     `


### PR DESCRIPTION
- **chore: remove ping.yml**
- **chore: add loading element in the use store**
- **hotfix: add fallback to placeholder + loading state on OAuth Button**
- **feat: add loading on OAuth button**
- **feat: add loading to log out button**
- **feat: change cursor to be pointer wher hovered in the avatar**
- **hotfix: add the setLoading on the handler**
- **fix: tried fixing the reload user function**
- **fix: remove the email changer**
- **fix: disable email changing feature**
- **feat: add button ui for leaderboard-refresh**
- **feat: add reloading**
- **feat: add redirection to conctact page**
- **feat: add the UI of the contact page**
- **feat: add mode toogle on the leaderboard**
- **fix: move mode toogle outside the back button**
- **fix: add separated loading on OAuth button**
- **hotfix: change loading ui**
- **build: add Dockerfile**
- **build: add .dockerignore**
- **chore: add docker file**
- **feat: add redirection to setting page**
- **feat: add header to setting page**
- **chore: add sidebar component**
- **feat: add setting page content**
- **feat: add fallback to uncreated section**
- **fix: UI and UX**
- **fix: place text in the button with justify-start to the left**
- **fix: try centering the loading page on the screen with good padding**
- **chore: create you need an account component**
- **chore: create useLogged store**
- **fix: no token handler**
- **fix: big fix of my life**
- **fix: icon color**
- **hotfix: blinded responsive**
- **fix: redirect user to the setting with Avatar**
- **fix: some fix**
- **chore: add delete room by id service**
- **chore: add delete room route**
- **chore: add deleteRoomById function to utils**
- **feat: add delete room functionnality**
- **fix: UI... add more margin on the bottom**
- **feat: create the create room section**
- **feat: add link copy handler**
- **chore: build**
- **feat: add leave button**
- **fix**
- **feat**
- **fix**
- **I'm done......**
- **fix: generate room with roomId**
- **chore: I forgot to save the prisma file...**
- **fix: add public to query**
